### PR TITLE
fix: Clean up README links and titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Run Flutter Appium Python Tests on TestMu AI (Formerly LambdaTest)
+﻿# Run Flutter Appium Python Tests on TestMu AI (Formerly LambdaTest)
 
 <p align="center">
   <a href="https://www.testmuai.com/"><img src="https://img.shields.io/badge/MADE%20BY%20TestMu%20AI-000000.svg?style=for-the-badge&labelColor=000" alt="Made by TestMu AI"></a>
@@ -17,10 +17,10 @@ With TestMu AI (Formerly LambdaTest), you can run Flutter Appium tests written i
 
 ### Prerequisites
 
-- [Python 3.x](https://www.python.org/downloads/)
-- [Appium Python client](https://pypi.org/project/Appium-Python-Client/) (`pip install Appium-Python-Client`)
-- [Flutter SDK](https://flutter.dev/docs/get-started/install) installed
-- A TestMu AI (Formerly LambdaTest) account — [sign up here](https://www.testmuai.com/register/)
+- Python 3.x
+- Appium Python client (`pip install Appium-Python-Client`)
+- Flutter SDK installed
+- A TestMu AI (Formerly LambdaTest) account — sign up here
 
 ### Setup
 


### PR DESCRIPTION
Removes non-template hyperlinks from Prerequisites, Setup, and Run tests sections. Fixes H1 title where needed.